### PR TITLE
itemDivider and lastItemTargetHeight

### DIFF
--- a/lib/drag_and_drop_list.dart
+++ b/lib/drag_and_drop_list.dart
@@ -188,7 +188,7 @@ class DragAndDropList implements DragAndDropListInterface {
                   onReorderOrAdd: params.onItemDropOnLastTarget,
                   child: lastTarget ??
                       Container(
-                        height: 20,
+                        height: params.lastItemTargetHeight,
                       ),
                 ),
               ],

--- a/lib/drag_and_drop_list_expansion.dart
+++ b/lib/drag_and_drop_list_expansion.dart
@@ -160,7 +160,7 @@ class DragAndDropListExpansion implements DragAndDropListExpansionInterface {
         onReorderOrAdd: params.onItemDropOnLastTarget,
         child: lastTarget ??
             Container(
-              height: 20,
+              height: params.lastItemTargetHeight,
             ),
       ));
     } else {
@@ -180,7 +180,7 @@ class DragAndDropListExpansion implements DragAndDropListExpansionInterface {
           onReorderOrAdd: params.onItemDropOnLastTarget,
           child: lastTarget ??
               Container(
-                height: 20,
+                height: params.lastItemTargetHeight,
               ),
         ),
       );

--- a/lib/drag_and_drop_list_expansion.dart
+++ b/lib/drag_and_drop_list_expansion.dart
@@ -131,24 +131,29 @@ class DragAndDropListExpansion implements DragAndDropListExpansionInterface {
       DragAndDropBuilderParameters params) {
     var contents = List<Widget>();
     if (children != null && children.isNotEmpty) {
-      children.forEach((element) => contents.add(DragAndDropItemWrapper(
-            child: element,
-            onPointerDown: params.onPointerDown,
-            onPointerUp: params.onPointerUp,
-            onPointerMove: params.onPointerMove,
-            onItemReordered: params.onItemReordered,
-            itemOnWillAccept: params.itemOnWillAccept,
-            sizeAnimationDuration: params.itemSizeAnimationDuration,
-            ghostOpacity: params.itemGhostOpacity,
-            ghost: params.itemGhost,
-            dragOnLongPress: params.dragOnLongPress,
-            draggingWidth: params.itemDraggingWidth,
-            axis: params.axis,
-            verticalAlignment: params.verticalAlignment,
-            dragHandle: params.dragHandle,
-            dragHandleOnLeft: params.dragHandleOnLeft,
-            decorationWhileDragging: params.itemDecorationWhileDragging,
-          )));
+      for (int i = 0; i < children.length; i++) {
+        contents.add(DragAndDropItemWrapper(
+          child: children[i],
+          onPointerDown: params.onPointerDown,
+          onPointerUp: params.onPointerUp,
+          onPointerMove: params.onPointerMove,
+          onItemReordered: params.onItemReordered,
+          itemOnWillAccept: params.itemOnWillAccept,
+          sizeAnimationDuration: params.itemSizeAnimationDuration,
+          ghostOpacity: params.itemGhostOpacity,
+          ghost: params.itemGhost,
+          dragOnLongPress: params.dragOnLongPress,
+          draggingWidth: params.itemDraggingWidth,
+          axis: params.axis,
+          verticalAlignment: params.verticalAlignment,
+          dragHandle: params.dragHandle,
+          dragHandleOnLeft: params.dragHandleOnLeft,
+          decorationWhileDragging: params.itemDecorationWhileDragging,
+        ));
+        if (params.itemDivider != null && i < children.length - 1) {
+          contents.add(params.itemDivider);
+        }
+      }
       contents.add(DragAndDropItemTarget(
         parent: this,
         parameters: params,


### PR DESCRIPTION
**Overview**
1. Apply the `itemDivider` property to items in the `DragAndDropListExpansion` widget.
2. Use the `lastItemTargetHeight` instead of the constant value of `20`.

**Side Note**
 I noticed that the `_generateDragAndDropListInnerContents` method is defined in the `DragAndDropList` and `DragAndDropListExpansion` classes. It has some duplicate code in both classes, and some code that is unique. Been thinking about ways to generalize & share the code but I'm new to Flutter and have some questions. Would you be willing to collaborate with me, maybe over Zoom or phone call?