### PR TITLE
Add a flag to ignore the divider on last list

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
@@ -113,7 +113,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
@@ -157,4 +157,4 @@ packages:
     source: hosted
     version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
+  dart: ">=2.10.0-110 <2.11.0"

--- a/lib/drag_and_drop_lists.dart
+++ b/lib/drag_and_drop_lists.dart
@@ -212,6 +212,9 @@ class DragAndDropLists extends StatefulWidget {
   /// A widget that will be displayed between each individual list.
   final Widget listDivider;
 
+  /// Whether it should put a divider on the last list or not.
+  final bool listDividerOnLastChild;
+
   /// The padding between each individual list.
   final EdgeInsets listPadding;
 
@@ -308,6 +311,7 @@ class DragAndDropLists extends StatefulWidget {
     this.listDecorationWhileDragging,
     this.listInnerDecoration,
     this.listDivider,
+    this.listDividerOnLastChild = true,
     this.listPadding,
     this.contentsWhenEmpty,
     this.listWidth = double.infinity,
@@ -449,7 +453,11 @@ class DragAndDropListsState extends State<DragAndDropLists> {
           listView = ListView.separated(
             scrollDirection: widget.axis,
             controller: _scrollController,
-            separatorBuilder: (_, index) => widget.listDivider,
+            separatorBuilder: (_, index) => widget.listDividerOnLastChild
+                ? widget.listDivider
+                : index + 1 >= (widget.children?.length ?? 0)
+                    ? Container()
+                    : widget.listDivider,
             itemCount: (widget.children?.length ?? 0) + 1,
             itemBuilder: (context, index) {
               if (index < (widget.children?.length ?? 0)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: drag_and_drop_lists
 description: A flutter package to allow drag-and-drop reordering of two-level lists.
 version: 0.2.8
-homepage: https://github.com/Zexuz/DragAndDropLists
+homepage: https://github.com/philip-brink/DragAndDropLists
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: drag_and_drop_lists
 description: A flutter package to allow drag-and-drop reordering of two-level lists.
 version: 0.2.8
-homepage: https://github.com/philip-brink/DragAndDropLists
+homepage: https://github.com/Zexuz/DragAndDropLists
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: drag_and_drop_lists
 description: A flutter package to allow drag-and-drop reordering of two-level lists.
-version: 0.2.7
+version: 0.2.8
 homepage: https://github.com/philip-brink/DragAndDropLists
 
 environment:


### PR DESCRIPTION
This flag allows me to ignore the last divider.

The left one is my current app, but the right one is the new update.
![Screenshot from 2020-11-05 16-32-58](https://user-images.githubusercontent.com/12451322/98261292-991eaa80-1f84-11eb-938a-8330f878d6f9.png)
