### PR TITLE
Fix for null crash and wrong handler usage

### DIFF
--- a/lib/drag_and_drop_item_wrapper.dart
+++ b/lib/drag_and_drop_item_wrapper.dart
@@ -30,7 +30,7 @@ class _DragAndDropItemWrapper extends State<DragAndDropItemWrapper>
   Widget build(BuildContext context) {
     Widget draggable;
     if (widget.child.canDrag) {
-      if (widget.parameters!.listDragHandle != null) {
+      if (widget.parameters!.itemDragHandle != null) {
         Widget feedback = Container(
           width: widget.parameters!.itemDraggingWidth ?? _containerSize.width,
           child: Stack(
@@ -47,7 +47,7 @@ class _DragAndDropItemWrapper extends State<DragAndDropItemWrapper>
                         DragHandleVerticalAlignment.top
                     ? null
                     : 0,
-                child: widget.parameters!.listDragHandle!,
+                child: widget.parameters!.itemDragHandle!,
               ),
             ],
           ),
@@ -78,7 +78,7 @@ class _DragAndDropItemWrapper extends State<DragAndDropItemWrapper>
                     _dragHandleSize = size!;
                   });
                 },
-                child: widget.parameters!.listDragHandle,
+                child: widget.parameters!.itemDragHandle,
               ),
               feedback: Transform.translate(
                 offset: _feedbackContainerOffset(),


### PR DESCRIPTION
This PR fixes a few important issue introduced in `0.3.0`: #33 and #34 

Both issues seems to be caused by minor typos.