### PR TITLE
Add pointer events

### DIFF
--- a/lib/drag_and_drop_builder_parameters.dart
+++ b/lib/drag_and_drop_builder_parameters.dart
@@ -8,6 +8,7 @@ import 'package:flutter/widgets.dart';
 typedef void OnPointerMove(PointerMoveEvent event);
 typedef void OnPointerUp(PointerUpEvent event);
 typedef void OnPointerDown(PointerDownEvent event);
+typedef void OnPointerCancel(PointerCancelEvent event);
 typedef void OnItemReordered(
   DragAndDropItem reorderedItem,
   DragAndDropItem receiverItem,
@@ -26,6 +27,7 @@ class DragAndDropBuilderParameters {
   final OnPointerMove? onPointerMove;
   final OnPointerUp? onPointerUp;
   final OnPointerDown? onPointerDown;
+  final OnPointerCancel? onPointerCancel;
   final OnItemReordered? onItemReordered;
   final OnItemDropOnLastTarget? onItemDropOnLastTarget;
   final OnListReordered? onListReordered;
@@ -64,6 +66,7 @@ class DragAndDropBuilderParameters {
     this.onPointerMove,
     this.onPointerUp,
     this.onPointerDown,
+    this.onPointerCancel,
     this.onItemReordered,
     this.onItemDropOnLastTarget,
     this.onListReordered,

--- a/lib/drag_and_drop_list_wrapper.dart
+++ b/lib/drag_and_drop_list_wrapper.dart
@@ -148,6 +148,7 @@ class _DragAndDropListWrapper extends State<DragAndDropListWrapper>
         onPointerMove: _onPointerMove,
         onPointerDown: widget.parameters.onPointerDown,
         onPointerUp: widget.parameters.onPointerUp,
+        onPointerCancel: widget.parameters.onPointerCancel,
       ),
     ];
 

--- a/lib/drag_and_drop_lists.dart
+++ b/lib/drag_and_drop_lists.dart
@@ -286,6 +286,16 @@ class DragAndDropLists extends StatefulWidget {
   /// https://github.com/flutter/flutter/issues/14842#issuecomment-371344881
   final bool removeTopPadding;
 
+  /// Respond to the DragAndDropLists' onPointerMove event. This exists to work
+  /// around a conflict in the Flutter engine where multiple Listeners at
+  /// different levels in the widget hierarchy cannot work together.
+  final OnPointerMove? listsOnPointerMove;
+
+  /// Respond to the DragAndDropLists' onPointerCancel event. This exists to
+  /// work around a conflict in the Flutter engine where multiple Listeners at
+  /// different levels in the widget hierarchy cannot work together.
+  final OnPointerCancel? listsOnPointerCancel;
+
   DragAndDropLists({
     required this.children,
     required this.onItemReorder,
@@ -336,6 +346,8 @@ class DragAndDropLists extends StatefulWidget {
     this.itemDragHandle,
     this.constrainDraggingAxis = true,
     this.removeTopPadding = false,
+    this.listsOnPointerMove,
+    this.listsOnPointerCancel,
     Key? key,
   }) : super(key: key) {
     if (listGhost == null &&
@@ -394,6 +406,7 @@ class DragAndDropListsState extends State<DragAndDropLists> {
       onPointerDown: _onPointerDown,
       onPointerUp: _onPointerUp,
       onPointerMove: _onPointerMove,
+      onPointerCancel: widget.listsOnPointerCancel,
       onItemReordered: _internalOnItemReorder,
       onItemDropOnLastTarget: _internalOnItemDropOnLastTarget,
       onListReordered: _internalOnListReorder,
@@ -679,6 +692,10 @@ class DragAndDropListsState extends State<DragAndDropLists> {
       _pointerXPosition = event.position.dx;
 
       _scrollList();
+    }
+
+    if (widget.listsOnPointerMove != null) {
+      widget.listsOnPointerMove!(event);
     }
   }
 


### PR DESCRIPTION
This exists to work around a conflict in the Flutter engine where
multiple Listeners at different levels in the widget hierarchy cannot
work together.

See https://github.com/flutter/flutter/issues/76525 et al