### PR TITLE
Optionally disable animating items when dropping

### DIFF
--- a/lib/drag_and_drop_builder_parameters.dart
+++ b/lib/drag_and_drop_builder_parameters.dart
@@ -59,6 +59,7 @@ class DragAndDropBuilderParameters {
   final DragHandle? itemDragHandle;
   final bool constrainDraggingAxis;
   final bool disableScrolling;
+  final bool animateItemsOnDrop;
 
   DragAndDropBuilderParameters({
     this.onPointerMove,
@@ -97,5 +98,6 @@ class DragAndDropBuilderParameters {
     this.itemDragHandle,
     this.constrainDraggingAxis = true,
     this.disableScrolling = false,
+    this.animateItemsOnDrop = true,
   });
 }

--- a/lib/drag_and_drop_item_wrapper.dart
+++ b/lib/drag_and_drop_item_wrapper.dart
@@ -193,7 +193,10 @@ class _DragAndDropItemWrapper extends State<DragAndDropItemWrapper>
           children: <Widget>[
             AnimatedSize(
               duration: Duration(
-                  milliseconds: widget.parameters!.itemSizeAnimationDuration),
+                  milliseconds: (_hoveredDraggable != null ||
+                          widget.parameters!.animateItemsOnDrop)
+                      ? widget.parameters!.itemSizeAnimationDuration
+                      : 1),
               alignment: Alignment.topLeft,
               child: _hoveredDraggable != null
                   ? Opacity(

--- a/lib/drag_and_drop_lists.dart
+++ b/lib/drag_and_drop_lists.dart
@@ -286,6 +286,10 @@ class DragAndDropLists extends StatefulWidget {
   /// https://github.com/flutter/flutter/issues/14842#issuecomment-371344881
   final bool removeTopPadding;
 
+  /// Whether to animate items in the list into place after they've been dropped
+  /// onto their target or not.
+  final bool animateItemsOnDrop;
+
   DragAndDropLists({
     required this.children,
     required this.onItemReorder,
@@ -336,6 +340,7 @@ class DragAndDropLists extends StatefulWidget {
     this.itemDragHandle,
     this.constrainDraggingAxis = true,
     this.removeTopPadding = false,
+    this.animateItemsOnDrop = true,
     Key? key,
   }) : super(key: key) {
     if (listGhost == null &&
@@ -419,6 +424,7 @@ class DragAndDropListsState extends State<DragAndDropLists> {
       itemDragHandle: widget.itemDragHandle,
       constrainDraggingAxis: widget.constrainDraggingAxis,
       disableScrolling: widget.disableScrolling,
+      animateItemsOnDrop: widget.animateItemsOnDrop,
     );
 
     DragAndDropListTarget dragAndDropListTarget = DragAndDropListTarget(


### PR DESCRIPTION
When this is enabled, items beneath the dropped item re-animate into
place after the user drops something in the list. This feels like a bug,
but I went ahead and made it an option in the interest of not changing
existing behavior for existing users of the library.

Note that the duration is set to 1 because the render animation system
ends up throwing an exception if it's set to 0. I tried replacing the
AnimatedSize widget entirely when this option was set, but swapping an
animated widget in right when we want it to animate means it doesn't
know what its previous size was, so it can't animate. In other words: a
duration of 1 feels wrong, but it's there for a reason.