### PR TITLE
AnimatedSize vsync Problem

### DIFF
--- a/lib/drag_and_drop_item_target.dart
+++ b/lib/drag_and_drop_item_target.dart
@@ -34,6 +34,7 @@ class _DragAndDropItemTarget extends State<DragAndDropItemTarget>
           crossAxisAlignment: widget.parameters.verticalAlignment,
           children: <Widget>[
             AnimatedSize(
+              vsync: this,
               duration: Duration(
                   milliseconds: widget.parameters.itemSizeAnimationDuration),
               alignment: Alignment.bottomCenter,

--- a/lib/drag_and_drop_item_wrapper.dart
+++ b/lib/drag_and_drop_item_wrapper.dart
@@ -179,6 +179,7 @@ class _DragAndDropItemWrapper extends State<DragAndDropItemWrapper>
       }
     } else {
       draggable = AnimatedSize(
+        vsync: this,
         duration: Duration(
             milliseconds: widget.parameters!.itemSizeAnimationDuration),
         alignment: Alignment.bottomCenter,
@@ -192,6 +193,7 @@ class _DragAndDropItemWrapper extends State<DragAndDropItemWrapper>
           crossAxisAlignment: widget.parameters!.verticalAlignment,
           children: <Widget>[
             AnimatedSize(
+              vsync: this,
               duration: Duration(
                   milliseconds: widget.parameters!.itemSizeAnimationDuration),
               alignment: Alignment.topLeft,

--- a/lib/drag_and_drop_list_target.dart
+++ b/lib/drag_and_drop_list_target.dart
@@ -35,6 +35,7 @@ class _DragAndDropListTarget extends State<DragAndDropListTarget>
     Widget visibleContents = Column(
       children: <Widget>[
         AnimatedSize(
+          vsync: this,
           duration: Duration(
               milliseconds: widget.parameters.listSizeAnimationDuration),
           alignment: widget.parameters.axis == Axis.vertical

--- a/lib/drag_and_drop_list_wrapper.dart
+++ b/lib/drag_and_drop_list_wrapper.dart
@@ -122,6 +122,7 @@ class _DragAndDropListWrapper extends State<DragAndDropListWrapper>
 
     var rowOrColumnChildren = <Widget>[
       AnimatedSize(
+        vsync: this,
         duration:
             Duration(milliseconds: widget.parameters.listSizeAnimationDuration),
         alignment: widget.parameters.axis == Axis.vertical


### PR DESCRIPTION
Hi,

I faced this issue, this changes fixed problem.

```
: Error: Required named parameter 'vsync' must be provided.
../…/lib/drag_and_drop_list_target.dart:31
        AnimatedSize(
                    ^
: Context: Found this candidate, but the arguments don't match.
../…/widgets/animated_size.dart:56
  const AnimatedSize({
        ^^^^^^^^^^^^

```

```
[✓] Flutter (Channel stable, 2.2.3, on Linux, locale en_US.utf8)
    • Flutter version 2.2.3 at /home/user/Applications/flutter
    • Framework revision f4abaa0735 (6 months ago), 2021-07-01 12:46:11 -0700
    • Engine revision 241c87ad80
    • Dart version 2.13.4

[!] Android toolchain - develop for Android devices (Android SDK version 30.0.3)
    • Android SDK at /home/gokhan/Android/Sdk
    • Platform android-31, build-tools 30.0.3
    • ANDROID_HOME = /home/gokhan/Android/Sdk
    • ANDROID_SDK_ROOT = /home/gokhan/Android/Sdk
    • Java binary at: /var/lib/snapd/snap/android-studio/115/android-studio/jre/bin/java
    • Java version OpenJDK Runtime Environment (build 11.0.10+0-b96-7249189)
    ✗ Android license status unknown.
      Run `flutter doctor --android-licenses` to accept the SDK licenses.
      See https://flutter.dev/docs/get-started/install/linux#android-setup for more details.

[✗] Chrome - develop for the web (Cannot find Chrome executable at google-chrome)
    ! Cannot find Chrome. Try setting CHROME_EXECUTABLE to a Chrome executable.

[✓] Android Studio (version 2020.3)
    • Android Studio at /var/lib/snapd/snap/android-studio/115/android-studio
    • Flutter plugin version 59.0.2
    • Dart plugin version 203.8292
    • Java version OpenJDK Runtime Environment (build 11.0.10+0-b96-7249189)

[✓] Connected device (1 available)
    • sdk gphone x86 (mobile) • emulator-5554 • android-x86 • Android 11 (API 30) (emulator)

! Doctor found issues in 2 categories.
```