### PR TITLE
Use `feedbackWidget` when also using the `itemDragHandle` property

### DIFF
--- a/lib/drag_and_drop_item_wrapper.dart
+++ b/lib/drag_and_drop_item_wrapper.dart
@@ -31,7 +31,7 @@ class _DragAndDropItemWrapper extends State<DragAndDropItemWrapper>
           width: widget.parameters!.itemDraggingWidth ?? _containerSize.width,
           child: Stack(
             children: [
-              widget.child.child,
+              widget.child.feedbackWidget ?? widget.child.child,
               Positioned(
                 right: widget.parameters!.itemDragHandle!.onLeft ? null : 0,
                 left: widget.parameters!.itemDragHandle!.onLeft ? 0 : null,


### PR DESCRIPTION
There is a bug in `DragAndDropItemWrapper` when using the `itemDragHandle` property. When set, this property builds a feedback widget differently than the other possibilities -- except it doesn't honor the `feedbackWidget` parameter of the `DragAndDropItem` class (it does in all other cases). 

This patch fixes that issue by defaulting to using a provided `feedbackWidget` Widget, and only falls back to the `child` (e.g. "normal" widget if `feedbackWidget` isn't provided.