### PR TITLE
Deprecated textstyle replaced with updated textstyle 

### DIFF
--- a/example/lib/basic_example.dart
+++ b/example/lib/basic_example.dart
@@ -1,5 +1,5 @@
 import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
-import 'package:example/navigation_drawer.dart';
+import 'package:example/navigation_drawer.dart' as drawer;
 import 'package:flutter/material.dart';
 
 class BasicExample extends StatefulWidget {
@@ -55,7 +55,7 @@ class _BasicExample extends State<BasicExample> {
       appBar: AppBar(
         title: const Text('Basic'),
       ),
-      drawer: const NavigationDrawer(),
+      drawer: const drawer.NavigationDrawer(),
       body: DragAndDropLists(
         children: _contents,
         onItemReorder: _onItemReorder,

--- a/example/lib/drag_handle_example.dart
+++ b/example/lib/drag_handle_example.dart
@@ -1,5 +1,5 @@
 import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
-import 'package:example/navigation_drawer.dart';
+import 'package:example/navigation_drawer.dart' as drawer;
 import 'package:flutter/material.dart';
 
 class DragHandleExample extends StatefulWidget {
@@ -26,7 +26,8 @@ class _DragHandleExample extends State<DragHandleExample> {
                   padding: const EdgeInsets.only(left: 8, bottom: 4),
                   child: Text(
                     'Header $index',
-                    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                    style: const TextStyle(
+                        fontWeight: FontWeight.bold, fontSize: 16),
                   ),
                 ),
               ],
@@ -38,7 +39,8 @@ class _DragHandleExample extends State<DragHandleExample> {
             child: Row(
               children: [
                 Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
                   child: Text(
                     'Sub $index.1',
                   ),
@@ -50,7 +52,8 @@ class _DragHandleExample extends State<DragHandleExample> {
             child: Row(
               children: [
                 Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
                   child: Text(
                     'Sub $index.2',
                   ),
@@ -62,7 +65,8 @@ class _DragHandleExample extends State<DragHandleExample> {
             child: Row(
               children: [
                 Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
                   child: Text(
                     'Sub $index.3',
                   ),
@@ -84,7 +88,7 @@ class _DragHandleExample extends State<DragHandleExample> {
       appBar: AppBar(
         title: const Text('Drag Handle'),
       ),
-      drawer: const NavigationDrawer(),
+      drawer: const drawer.NavigationDrawer(),
       body: DragAndDropLists(
         children: _contents,
         onItemReorder: _onItemReorder,

--- a/example/lib/drag_into_list_example.dart
+++ b/example/lib/drag_into_list_example.dart
@@ -1,6 +1,6 @@
 import 'package:drag_and_drop_lists/drag_and_drop_list_interface.dart';
 import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
-import 'package:example/navigation_drawer.dart';
+import 'package:example/navigation_drawer.dart'as drawer;
 import 'package:flutter/material.dart';
 
 class DragIntoListExample extends StatefulWidget {
@@ -19,7 +19,7 @@ class _DragIntoListExample extends State<DragIntoListExample> {
       appBar: AppBar(
         title: const Text('Drag Into List'),
       ),
-      drawer: const NavigationDrawer(),
+      drawer: const drawer.NavigationDrawer(),
       body: Column(
         children: <Widget>[
           Flexible(

--- a/example/lib/expansion_tile_example.dart
+++ b/example/lib/expansion_tile_example.dart
@@ -1,5 +1,5 @@
 import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
-import 'package:example/navigation_drawer.dart';
+import 'package:example/navigation_drawer.dart' as drawer;
 import 'package:flutter/material.dart';
 
 class ExpansionTileExample extends StatefulWidget {
@@ -36,7 +36,7 @@ class _ListTileExample extends State<ExpansionTileExample> {
       appBar: AppBar(
         title: const Text('Expansion Tiles'),
       ),
-      drawer: const NavigationDrawer(),
+      drawer: const drawer.NavigationDrawer(),
       body: DragAndDropLists(
         children: List.generate(_lists.length, (index) => _buildList(index)),
         onItemReorder: _onItemReorder,

--- a/example/lib/fixed_example.dart
+++ b/example/lib/fixed_example.dart
@@ -1,5 +1,5 @@
 import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
-import 'package:example/navigation_drawer.dart';
+import 'package:example/navigation_drawer.dart' as drawer;
 import 'package:flutter/material.dart';
 
 class FixedExample extends StatefulWidget {
@@ -59,7 +59,7 @@ class _FixedExample extends State<FixedExample> {
       appBar: AppBar(
         title: const Text('Fixed Items'),
       ),
-      drawer: const NavigationDrawer(),
+      drawer: const drawer.NavigationDrawer(),
       body: DragAndDropLists(
         children: _contents,
         onItemReorder: _onItemReorder,

--- a/example/lib/horizontal_example.dart
+++ b/example/lib/horizontal_example.dart
@@ -1,5 +1,5 @@
 import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
-import 'package:example/navigation_drawer.dart';
+import 'package:example/navigation_drawer.dart' as drawer;
 import 'package:flutter/material.dart';
 
 class HorizontalExample extends StatefulWidget {
@@ -36,7 +36,7 @@ class _HorizontalExample extends State<HorizontalExample> {
       appBar: AppBar(
         title: const Text('Horizontal'),
       ),
-      drawer: const NavigationDrawer(),
+      drawer: const drawer.NavigationDrawer(),
       body: DragAndDropLists(
         children: List.generate(_lists.length, (index) => _buildList(index)),
         onItemReorder: _onItemReorder,
@@ -75,7 +75,7 @@ class _HorizontalExample extends State<HorizontalExample> {
               padding: const EdgeInsets.all(10),
               child: Text(
                 'Header ${innerList.name}',
-                style: Theme.of(context).primaryTextTheme.headline6,
+                style: Theme.of(context).primaryTextTheme.titleLarge,
               ),
             ),
           ),
@@ -93,7 +93,7 @@ class _HorizontalExample extends State<HorizontalExample> {
               padding: const EdgeInsets.all(10),
               child: Text(
                 'Footer ${innerList.name}',
-                style: Theme.of(context).primaryTextTheme.headline6,
+                style: Theme.of(context).primaryTextTheme.titleLarge,
               ),
             ),
           ),

--- a/example/lib/list_tile_example.dart
+++ b/example/lib/list_tile_example.dart
@@ -1,5 +1,5 @@
 import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
-import 'package:example/navigation_drawer.dart';
+import 'package:example/navigation_drawer.dart' as drawer;
 import 'package:flutter/material.dart';
 
 class ListTileExample extends StatefulWidget {
@@ -76,7 +76,7 @@ class _ListTileExample extends State<ListTileExample> {
       appBar: AppBar(
         title: const Text('List Tiles'),
       ),
-      drawer: const NavigationDrawer(),
+      drawer: const drawer.NavigationDrawer(),
       body: DragAndDropLists(
         children: _contents,
         onItemReorder: _onItemReorder,
@@ -85,7 +85,8 @@ class _ListTileExample extends State<ListTileExample> {
           padding: const EdgeInsets.symmetric(vertical: 30.0),
           child: Center(
             child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 40.0, horizontal: 100.0),
+              padding:
+                  const EdgeInsets.symmetric(vertical: 40.0, horizontal: 100.0),
               decoration: BoxDecoration(
                 border: Border.all(),
                 borderRadius: BorderRadius.circular(7.0),
@@ -106,7 +107,7 @@ class _ListTileExample extends State<ListTileExample> {
             Text(
               'Empty List',
               style: TextStyle(
-                  color: Theme.of(context).textTheme.caption!.color,
+                  color: Theme.of(context).textTheme.bodySmall!.color,
                   fontStyle: FontStyle.italic),
             ),
             const Expanded(

--- a/example/lib/sliver_example.dart
+++ b/example/lib/sliver_example.dart
@@ -1,5 +1,5 @@
 import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
-import 'package:example/navigation_drawer.dart';
+import 'package:example/navigation_drawer.dart' as drawer;
 import 'package:flutter/material.dart';
 
 class SliverExample extends StatefulWidget {
@@ -61,7 +61,7 @@ class _SliverExample extends State<SliverExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      drawer: const NavigationDrawer(),
+      drawer: const drawer.NavigationDrawer(),
       body: CustomScrollView(
         controller: _scrollController,
         slivers: <Widget>[
@@ -73,7 +73,7 @@ class _SliverExample extends State<SliverExample> {
                 alignment: Alignment.bottomCenter,
                 child: Text(
                   'Slivers',
-                  style: Theme.of(context).primaryTextTheme.headline1,
+                  style: Theme.of(context).primaryTextTheme.displayLarge,
                 ),
               ),
             ),

--- a/lib/programmatic_expansion_tile.dart
+++ b/lib/programmatic_expansion_tile.dart
@@ -129,7 +129,7 @@ class ProgrammaticExpansionTileState extends State<ProgrammaticExpansionTile>
         _controller.drive(_backgroundColorTween.chain(_easeOutTween));
 
     _isExpanded = PageStorage.of(context)
-            ?.readState(context, identifier: widget.listKey) as bool? ??
+            .readState(context, identifier: widget.listKey) as bool? ??
         widget.initiallyExpanded;
     if (_isExpanded) _controller.value = 1.0;
 
@@ -176,7 +176,7 @@ class ProgrammaticExpansionTileState extends State<ProgrammaticExpansionTile>
           });
         }
         PageStorage.of(context)
-            ?.writeState(context, _isExpanded, identifier: widget.listKey);
+            .writeState(context, _isExpanded, identifier: widget.listKey);
       });
       if (widget.onExpansionChanged != null) {
         widget.onExpansionChanged!(_isExpanded);
@@ -233,7 +233,7 @@ class ProgrammaticExpansionTileState extends State<ProgrammaticExpansionTile>
     final ThemeData theme = Theme.of(context);
     _borderColorTween.end = theme.dividerColor;
     _headerColorTween
-      ..begin = theme.textTheme.subtitle1!.color
+      ..begin = theme.textTheme.displayLarge!.color
       ..end = theme.colorScheme.secondary;
     _iconColorTween
       ..begin = theme.unselectedWidgetColor


### PR DESCRIPTION
After flutter 3.19 textstyle api is updated following [https://docs.flutter.dev/release/breaking-changes/3-19-deprec](url) . Changes made in app by regarding to this. 

NavigationDrawer causing conflict with another api from fluter library, import is specified using 'as'